### PR TITLE
Fix rule_set problem

### DIFF
--- a/template/render_dns.go
+++ b/template/render_dns.go
@@ -133,7 +133,7 @@ func (t *Template) renderDNS(metadata M.Metadata, options *option.Options) error
 						Server:  DNSLocalTag,
 					},
 				})
-			} else {
+			} else if len(t.CustomRuleSet) == 0 {
 				options.DNS.Rules = append(options.DNS.Rules, option.DNSRule{
 					Type: C.RuleTypeDefault,
 					DefaultOptions: option.DefaultDNSRule{
@@ -149,28 +149,31 @@ func (t *Template) renderDNS(metadata M.Metadata, options *option.Options) error
 						ClashMode: clashModeRule,
 						Server:    DNSDefaultTag,
 					},
-				}, option.DNSRule{
-					Type: C.RuleTypeLogical,
-					LogicalOptions: option.LogicalDNSRule{
-						Mode: C.LogicalTypeAnd,
-						Rules: []option.DNSRule{
-							{
-								Type: C.RuleTypeDefault,
-								DefaultOptions: option.DefaultDNSRule{
-									RuleSet: []string{"geosite-geolocation-!cn"},
-									Invert:  true,
-								},
-							},
-							{
-								Type: C.RuleTypeDefault,
-								DefaultOptions: option.DefaultDNSRule{
-									RuleSet: []string{"geoip-cn"},
-								},
-							},
-						},
-						Server: DNSLocalTag,
-					},
 				})
+				if len(t.CustomRuleSet) == 0 {
+					options.DNS.Rules = append(options.DNS.Rules, option.DNSRule{
+						Type: C.RuleTypeLogical,
+						LogicalOptions: option.LogicalDNSRule{
+							Mode: C.LogicalTypeAnd,
+							Rules: []option.DNSRule{
+								{
+									Type: C.RuleTypeDefault,
+									DefaultOptions: option.DefaultDNSRule{
+										RuleSet: []string{"geosite-geolocation-!cn"},
+										Invert:  true,
+									},
+								},
+								{
+									Type: C.RuleTypeDefault,
+									DefaultOptions: option.DefaultDNSRule{
+										RuleSet: []string{"geoip-cn"},
+									},
+								},
+							},
+							Server: DNSLocalTag,
+						},
+					})
+				}
 			}
 		}
 	} else {

--- a/template/render_route.go
+++ b/template/render_route.go
@@ -128,7 +128,7 @@ func (t *Template) renderRoute(metadata M.Metadata, options *option.Options) err
 						Outbound: directTag,
 					},
 				})
-			} else {
+			} else if len(t.CustomRuleSet) == 0 {
 				options.Route.Rules = append(options.Route.Rules, option.Rule{
 					Type: C.RuleTypeDefault,
 					DefaultOptions: option.DefaultRule{


### PR DESCRIPTION
![image](https://github.com/SagerNet/serenity/assets/59752988/401a0db0-3d93-4e49-96d7-8a8fd1195f63)

![image](https://github.com/SagerNet/serenity/assets/59752988/c6e365c0-5127-4fbb-b430-f72dfd82b5f9)
在CustomDNSRules=0 DisableTrafficBypass=false   DisableRuleSet=false 会添加程序自定义的ruleset,但是相关ruleset设置在CustomRuleSet=0才添加,生成的配置不正确