### PR TITLE
fix: preserve `type` while unmarshalling RuleSet

### DIFF
--- a/option/template.go
+++ b/option/template.go
@@ -113,7 +113,7 @@ func (r *RuleSet) UnmarshalJSON(content []byte) error {
 	if r.Type == C.RuleSetTypeGitHub {
 		return option.UnmarshallExcluded(content, (*_RuleSet)(r), &r.GitHubOptions)
 	} else {
-		return option.UnmarshallExcluded(content, (*_RuleSet)(r), &r.DefaultOptions)
+		return json.UnmarshalDisallowUnknownFields(content, &r.DefaultOptions)
 	}
 }
 


### PR DESCRIPTION
`option.UnmarshallExcluded` here will exclude `type`, which is required by `option.RuleSet` (`boxOption.RuleSet`).