### PR TITLE
fix #38: use `base64.RawURLEncoding` for url safe base64 decode

### DIFF
--- a/subscription/parser/raw.go
+++ b/subscription/parser/raw.go
@@ -39,6 +39,6 @@ func decodeBase64URLSafe(content string) (string, error) {
 	content = strings.ReplaceAll(content, "/", "_")
 	content = strings.ReplaceAll(content, "+", "-")
 	content = strings.ReplaceAll(content, "=", "")
-	result, err := base64.StdEncoding.DecodeString(content)
+	result, err := base64.RawURLEncoding.DecodeString(content)
 	return string(result), err
 }


### PR DESCRIPTION
replace `base64.StdEncoding.DecodeString` with `base64.RawURLEncoding` to correctly decode URL Safe Base64 encoded strings