### PR TITLE
Fix nil check of metadata.Version

### DIFF
--- a/server/profile.go
+++ b/server/profile.go
@@ -163,7 +163,7 @@ func (p *Profile) Render(metadata metadata.Metadata) (*boxOption.Options, error)
 	if err != nil {
 		return nil, err
 	}
-	if metadata.Version != nil || metadata.Version.GreaterThanOrEqual(semver.ParseVersion("1.12.0-alpha.1")) {
+	if metadata.Version != nil && metadata.Version.GreaterThanOrEqual(semver.ParseVersion("1.12.0-alpha.1")) {
 		options.Endpoints = endpoints
 	}
 	options, err = badjson.Omitempty(ctx, options)


### PR DESCRIPTION
Causing the following crash if `Version` is not available:

```text
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x56350145c98d]

goroutine 1 [running]:
github.com/sagernet/serenity/server.(*Profile).Render(0xc000184210, {{0x0, 0x0}, {0x0, 0x0}, 0x0})
        github.com/sagernet/serenity/server/profile.go:166 +0xb6d
github.com/sagernet/serenity/server.(*Server).RenderHeadless(0xc0001842c0?, {0x7fffff53768b?, 0x7?}, {{0x0, 0x0}, {0x0, 0x0}, 0x0})
        github.com/sagernet/serenity/server/server_render.go:112 +0xc5
main.export({0x7fffff53768b, 0x7})
        github.com/sagernet/serenity/cmd/serenity/cmd_export.go:100 +0x733
main.init.func2(0xc0001d6200?, {0xc0003ad540?, 0x1?, 0x5635018488e6?})
        github.com/sagernet/serenity/cmd/serenity/cmd_export.go:35 +0x35
github.com/spf13/cobra.(*Command).execute(0x5635024a3600, {0xc0003ad4f0, 0x5, 0x5})
        github.com/spf13/cobra@v1.9.1/command.go:1019 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0x5635024a3e40)
        github.com/spf13/cobra@v1.9.1/command.go:1148 +0x46f
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.9.1/command.go:1071
main.main()
        github.com/sagernet/serenity/cmd/serenity/main.go:37 +0x1e
```