### PR TITLE
fix: enable_fakeip not work in sing-box 1.12

### DIFF
--- a/template/render_dns.go
+++ b/template/render_dns.go
@@ -146,7 +146,8 @@ func (t *Template) renderDNS(ctx context.Context, metadata M.Metadata, options *
 				inet6Range = (*badoption.Prefix)(common.Ptr(netip.MustParsePrefix("fc00::/18")))
 			}
 			options.DNS.Servers = append(options.DNS.Servers, option.DNSServerOptions{
-				Tag: DNSFakeIPTag,
+				Tag:  DNSFakeIPTag,
+				Type: C.DNSTypeFakeIP,
 				Options: &option.FakeIPDNSServerOptions{
 					Inet4Range: inet4Range,
 					Inet6Range: inet6Range,


### PR DESCRIPTION
In the original version, I encountered the following problems:

when `template.eable_fakeip: true`
❯ ./serenity -c config.json export default --version 1.12.4 > client.json
FATAL[0000] render options: omitempty: unmarshal new object: dns.servers[2].inet4_range: json: unknown field "inet4_range"

After modification of template/render_dns.go, it can work now.