### PR TITLE
Optimize outbounds sorting: prioritize regex matches, followed by others

### DIFF
--- a/template/render_outbounds.go
+++ b/template/render_outbounds.go
@@ -208,7 +208,7 @@ func (t *Template) renderOutbounds(metadata M.Metadata, options *boxOption.Optio
 		}
 		sort.Strings(extraTags)
 		if len(extraTags) == 0 || extraGroup.filter != nil || extraGroup.exclude != nil {
-			extraTags = append(extraTags, common.Filter(common.FlatMap(subscriptions, func(it *subscription.Subscription) []string {
+			extraTags = append(common.Filter(common.FlatMap(subscriptions, func(it *subscription.Subscription) []string {
 				return common.Map(it.Servers, outboundToString)
 			}), func(outboundTag string) bool {
 				if len(extraGroup.filter) > 0 {
@@ -226,7 +226,7 @@ func (t *Template) renderOutbounds(metadata M.Metadata, options *boxOption.Optio
 					}
 				}
 				return true
-			})...)
+			}), extraTags...)
 		}
 		groupOutbound := boxOption.Outbound{
 			Tag:  extraGroup.Tag,


### PR DESCRIPTION
当前是订阅在最前面，现在 selector 的默认策略是选第一个，默认选中的出口不是期望的。

配置

```json
{
          "tag": "🇭🇰 香港",
          "type": "selector",
          "filter": "(?i)港|hk|hongkong|hong kong",
          "target": "global"
 }
```

优化前

```json
{
          "tag": "🇭🇰 香港",
          "type": "selector",
           "outbounds":  [
                  "subs"，
                  "hk01",
                  "hk02",
                  "hk03"
           ]
 }

```

优化后

```json
{
          "tag": "🇭🇰 香港",
          "type": "selector",
           "outbounds":  [
                  "hk01",
                  "hk02",
                  "hk03",
                  "subs"
           ]
 }

```